### PR TITLE
Update gdf v2.51

### DIFF
--- a/libgdf/src/EventDescriptor.cpp
+++ b/libgdf/src/EventDescriptor.cpp
@@ -196,7 +196,7 @@ namespace gdf
         {
             desc = "";
             int i =0;
-            while( value[pos+i] != 0 && (pos+i < tagfieldlength)) {
+            while( (pos + i < tagfieldlength) && value[pos+i] != 0 ) {
                 desc.push_back(value[pos+i]);
                 i++;
             }

--- a/libgdf/src/GDFHeaderAccess.cpp
+++ b/libgdf/src/GDFHeaderAccess.cpp
@@ -403,6 +403,7 @@ namespace gdf
         hdr.getTagHeader_readonly( ).toStream( out );
         uint16 header3LenBlocks = mh->get_header_length() - (1+ns);
         assert( out.tellp() == std::streampos(256+256*ns+256*header3LenBlocks));
+        (void)header3LenBlocks; // To prevent -Werror=unused-variable in a release build.
 
         return out;
     }
@@ -417,8 +418,13 @@ namespace gdf
         MainHeader *mh = &hdr.m_mainhdr;
         mh->version_id.fromstream( in );
         int gdf_version_int = mh->getGdfVersionInt();
+#ifdef ALLOW_GDF_V_251
+        if (gdf_version_int < 210 || gdf_version_int > 251)
+#else
         if (gdf_version_int < 210 || gdf_version_int > 220)
+#endif
             throw exception::incompatible_gdf_version (mh->get_version_id ());
+
         mh->patient_id.fromstream( in );
         mh->reserved_1.fromstream( in );
         mh->patient_drugs.fromstream( in );
@@ -484,6 +490,12 @@ namespace gdf
                 {
                 case 0:
                     break;
+#ifdef ALLOW_GDF_V_251
+                default:
+                    evd.fromTagField(tagfield);
+                    taghdr.setEventDescriptor(evd);
+                    break;
+#else
                 case 1:
                     evd.fromTagField(tagfield);
                     taghdr.setEventDescriptor(evd);
@@ -491,6 +503,7 @@ namespace gdf
                 default:
                     throw exception::feature_not_implemented("Only tag==1 is supported in this build");
                     break;
+#endif
                 }
             }
             taghdr.setLength();

--- a/libgdf/src/Reader.cpp
+++ b/libgdf/src/Reader.cpp
@@ -67,8 +67,11 @@ namespace gdf
         {
             size_t samplesize = datatype_size( m_header.getSignalHeader_readonly( i ).get_datatype( ) );
             m_record_length += samplesize * m_header.getSignalHeader_readonly( i ).get_samples_per_record( );
-
+#ifdef ALLOW_GDF_V_251
+            double fs = m_header.getSignalHeader( i ).get_samples_per_record( );
+#else
             double fs = m_header.getSignalHeader( i ).get_samples_per_record( ) * m_header.getMainHeader_readonly().get_datarecord_duration(1) / m_header.getMainHeader_readonly().get_datarecord_duration(0);
+#endif
             m_header.getSignalHeader( i ).set_samplerate( boost::numeric_cast<uint32>(fs) );
         }
 
@@ -145,8 +148,11 @@ namespace gdf
         }
 
         buffer.resize( signal_indices.size() );
-
+#ifdef ALLOW_GDF_V_251
+        double record_rate = 1;
+#else
         double record_rate = m_header.getMainHeader_readonly().get_datarecord_duration(1) / m_header.getMainHeader_readonly().get_datarecord_duration(0);
+#endif
         size_t record = boost::numeric_cast<size_t>( floor( start_time * record_rate ) );
 
 

--- a/libgdf/src/TagHeader.cpp
+++ b/libgdf/src/TagHeader.cpp
@@ -56,6 +56,22 @@ namespace gdf
             gdf::TagField tagfield(0);
             tagfield.fromStream(stream); 
             tag = tagfield.getTagNumber();
+#ifdef ALLOW_GDF_V_251
+            if (tag == 0)
+            {
+                // Zero tag value indicates end of Header 3. See first row of Table 10 in GDF standard.
+                header3unpaddedsize += 1;
+            }
+            else if (1 <= tag && tag <= 13)
+            {
+                header3unpaddedsize += tagfield.getLength();
+                this->addTagField( tagfield );
+            }
+            else
+            {
+                throw exception::feature_not_implemented("Only tag==1..13 are supported in this build");
+            }
+#else
             switch( tag )
             {
             case 0:
@@ -70,6 +86,7 @@ namespace gdf
                 throw exception::feature_not_implemented("Only tag==1 is supported in this build");
                 break;
             }
+#endif
         }
         // consume the padding bytes that make Header 3 a multiple of 256 bytes
         size_t ns = hdr.getMainHeader_readonly().get_num_signals( );


### PR DESCRIPTION
By defining ALLOW_GDF_V_251 macro, you can turn on my changes that allow the use of newer GDF files than v2.20. I haven't tested whether the new tags are read correctly, because I don't really need those values in my project. Somebody else will have to do that...

The second commit fixes a clear bug.