### PR TITLE
[Fix] Removed unused variables

### DIFF
--- a/libgdf/src/GDFHeaderAccess.cpp
+++ b/libgdf/src/GDFHeaderAccess.cpp
@@ -23,11 +23,6 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <list>
 #include <string>
-//#include <iostream>
-
-const double epsilon_d = 1e-15;
-const double epsilon_f = 1e-15;
-const double epsilon_i = 1;
 
 
 namespace gdf


### PR DESCRIPTION
These caused errors with the clang compiler.