### PR TITLE
Avoid deprecated way of checking system endianess

### DIFF
--- a/libgdf/include/GDF/Types.h
+++ b/libgdf/include/GDF/Types.h
@@ -21,7 +21,7 @@
 
 #include "Exceptions.h"
 #include <boost/cstdint.hpp>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include <iostream>
 
 namespace gdf
@@ -74,9 +74,9 @@ namespace gdf
     template<typename T>
     void writeLittleEndian( std::ostream &out, T item )
     {
-#if defined(BOOST_LITTLE_ENDIAN)
+#if defined(BOOST_ENDIAN_LITTLE_BYTE)
         out.write( reinterpret_cast<const char*>(&item), sizeof(item) );
-#elif defined(BOOST_BIG_ENDIAN)
+#elif defined(BOOST_ENDIAN_BIG_BYTE)
         const char* p = reinterpret_cast<const char*>(&item) + sizeof(item)-1;
         for( size_t i=0; i<sizeof(item); i++ )
             out.write( p--, 1 );
@@ -88,9 +88,9 @@ namespace gdf
     template<typename T>
     void readLittleEndian( std::istream &in, T &item )
     {
-#if defined(BOOST_LITTLE_ENDIAN)
+#if defined(BOOST_ENDIAN_LITTLE_BYTE)
         in.read( reinterpret_cast<char*>(&item), sizeof(item) );
-#elif defined(BOOST_BIG_ENDIAN)
+#elif defined(BOOST_ENDIAN_BIG_BYTE)
         char* p = reinterpret_cast<char*>(&item) + sizeof(item)-1;
         for( size_t i=0; i<sizeof(item); i++ )
     in.read( p--, 1 );


### PR DESCRIPTION
According to file /usr/include/boost/predef/detail/endian_compat.h,
“[t]he use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please
include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE
instead.”

Without this patch, compilation faisl for boost 1.74.  However, it
succeeds for boost 1.71.