### PR TITLE
Fix usage of BOOST_ENDIAN_(BIG|LITTLE)_BYTE

### DIFF
--- a/libgdf/include/GDF/Types.h
+++ b/libgdf/include/GDF/Types.h
@@ -74,9 +74,9 @@ namespace gdf
     template<typename T>
     void writeLittleEndian( std::ostream &out, T item )
     {
-#if defined(BOOST_ENDIAN_LITTLE_BYTE)
+#if BOOST_ENDIAN_LITTLE_BYTE
         out.write( reinterpret_cast<const char*>(&item), sizeof(item) );
-#elif defined(BOOST_ENDIAN_BIG_BYTE)
+#elif BOOST_ENDIAN_BIG_BYTE
         const char* p = reinterpret_cast<const char*>(&item) + sizeof(item)-1;
         for( size_t i=0; i<sizeof(item); i++ )
             out.write( p--, 1 );
@@ -88,9 +88,9 @@ namespace gdf
     template<typename T>
     void readLittleEndian( std::istream &in, T &item )
     {
-#if defined(BOOST_ENDIAN_LITTLE_BYTE)
+#if BOOST_ENDIAN_LITTLE_BYTE
         in.read( reinterpret_cast<char*>(&item), sizeof(item) );
-#elif defined(BOOST_ENDIAN_BIG_BYTE)
+#elif BOOST_ENDIAN_BIG_BYTE
         char* p = reinterpret_cast<char*>(&item) + sizeof(item)-1;
         for( size_t i=0; i<sizeof(item); i++ )
     in.read( p--, 1 );


### PR DESCRIPTION
The macros BOOST_ENDIAN_BIG_BYTE and BOOST_ENDIAN_LITTLE_BYTE are
always defined, such that my patch proposed in commit bacea76 (PR #5)
does not really work, since the first #if test always succeded.
Instead of testing for the existence of their definitions, we must
test for the value of those macros.

For more context, see Debian [Bug#978612](https://bugs.debian.org/978612).