### PR TITLE
Allow compilation against g++ 11

### DIFF
--- a/libgdf/include/GDF/EventConverter.h
+++ b/libgdf/include/GDF/EventConverter.h
@@ -31,8 +31,7 @@ namespace gdf
     ///        using the flag 0x8000 which marks the type of mode 1 stop events
     /// @throws general if events could not be converted
     std::vector<Mode3Event> convertMode1EventsIntoMode3Events (std::vector<Mode1Event>
-                                                               const& mode_1_events)
-        throw (exception::general);
+                                                               const& mode_1_events);
 }
 
 #endif

--- a/libgdf/src/EventConverter.cpp
+++ b/libgdf/src/EventConverter.cpp
@@ -34,7 +34,6 @@ namespace gdf
 
     //-------------------------------------------------------------------------
     vector<Mode3Event> convertMode1EventsIntoMode3Events (vector<Mode1Event> const& mode_1_events)
-            throw (exception::general)
     {
         vector<Mode3Event> mode_3_events;
 


### PR DESCRIPTION
Dynamic exception specifications are removed in C++17. Removing the
"throw" statements allow the compilation against version 11 of g++.