### PR TITLE
V2 51

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,10 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -yq libboost-all-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade cmake
+        sudo apt-get install -yq libboost-all-dev
       
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project( libGDF CXX)
 
 option( BUILD_TESTING "Build tests" OFF )
 
+set(CMAKE_CXX_STANDARD 11)
+
 if( WIN32 )
 	set( BUILD_SHARED_LIBS false CACHE BOOL "Whether we shall build shared or dynamic libraries." )
 	option( BUILD_PYTHON_MODULES "Build python modules" OFF )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif( WIN32 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
-set( GDF_SOURCE_ROOT ${Project_SOURCE_DIR} )
+set( GDF_SOURCE_ROOT ${PROJECT_SOURCE_DIR} )
 
 add_subdirectory( libgdf )
 add_subdirectory( tools )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+message("cmake version: ${CMAHE_VERSION}")
 cmake_minimum_required( VERSION 3.12 )
 project( libGDF CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required( VERSION 2.8 )
-#project( GDF )
+cmake_minimum_required( VERSION 3.12 )
+project( libGDF CXX)
 
 option( BUILD_TESTING "Build tests" OFF )
 

--- a/libgdf/CMakeLists.txt
+++ b/libgdf/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required( VERSION 2.8 )
 project( GDF )
 
+option(VERSION_251 "Allow support of GDF 2.51" OFF)
+
+if (VERSION_251)
+        add_compile_definitions(ALLOW_GDF_V_251)
+endif()
+
 if( UNIX )
         add_definitions( -Wall -Wextra -pedantic -Werror -fPIC )
 elseif( MINGW )

--- a/libgdf/CMakeLists.txt
+++ b/libgdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.12 )
 project( GDF )
 
 option(VERSION_251 "Allow support of GDF 2.51" OFF)

--- a/libgdf/include/GDF/EventDescriptor.h
+++ b/libgdf/include/GDF/EventDescriptor.h
@@ -80,7 +80,7 @@ namespace gdf
         int getNumUserDesc( ) {return m_userdesc.size();}
         
         // Populates class instance from a T-L-V triple.
-        void fromTagField( TagField &tf );
+        void fromTagField(const TagField &tf );
 
         // Copies table of user-specified descriptions into a T-L-V triple.
         TagField toTagField(  );

--- a/libgdf/include/GDF/SignalHeader.h
+++ b/libgdf/include/GDF/SignalHeader.h
@@ -37,7 +37,12 @@ namespace gdf
         GDF_DECLARE_HEADERITEM( physmax, float64, 112 )
         GDF_DECLARE_HEADERITEM( digmin, float64, 120 )
         GDF_DECLARE_HEADERITEM( digmax, float64, 128 )
+#ifdef ALLOW_GDF_V_251
+        GDF_DECLARE_RESERVED( reserved_1, 136, 64 )
+        GDF_DECLARE_HEADERITEM( toffset, float32, 200 )
+#else
         GDF_DECLARE_RESERVED( reserved_1, 136, 68 )
+#endif
         GDF_DECLARE_HEADERITEM( lowpass, float32, 204 )
         GDF_DECLARE_HEADERITEM( highpass, float32, 208 )
         GDF_DECLARE_HEADERITEM( notch, float32, 212 )
@@ -57,6 +62,7 @@ namespace gdf
             GDF_ASSIGN_HEADERITEM( digmin )
             GDF_ASSIGN_HEADERITEM( digmax )
             GDF_ASSIGN_RESERVED( reserved_1 )
+            GDF_ASSIGN_HEADERITEM( toffset )
             GDF_ASSIGN_HEADERITEM( lowpass )
             GDF_ASSIGN_HEADERITEM( highpass )
             GDF_ASSIGN_HEADERITEM( notch )
@@ -101,6 +107,7 @@ namespace gdf
             else if( item == "physmax" ) set_physmax( numeric_cast<float64>(value) );
             else if( item == "digmin" ) set_digmin( numeric_cast<float64>(value) );
             else if( item == "digmax" ) set_digmax( numeric_cast<float64>(value) );
+            else if( item == "toffset" ) set_toffset( numeric_cast<float32>(value) );
             else if( item == "lowpass" ) set_lowpass( numeric_cast<float32>(value) );
             else if( item == "highpass" ) set_highpass( numeric_cast<float32>(value) );
             else if( item == "notch" ) set_notch( numeric_cast<float32>(value) );
@@ -118,6 +125,7 @@ namespace gdf
             else if( item == "physmax" ) return numeric_cast<T>(get_physmax( ));
             else if( item == "digmin" ) return numeric_cast<T>(get_digmin( ));
             else if( item == "digmax" ) return numeric_cast<T>(get_digmax( ));
+            else if( item == "toffset" ) return numeric_cast<T>(get_toffset( ));
             else if( item == "lowpass" ) return numeric_cast<T>(get_lowpass( ));
             else if( item == "highpass" ) return numeric_cast<T>(get_highpass( ));
             else if( item == "notch" ) return numeric_cast<T>(get_notch( ));

--- a/libgdf/include/GDF/SignalHeader.h
+++ b/libgdf/include/GDF/SignalHeader.h
@@ -107,7 +107,9 @@ namespace gdf
             else if( item == "physmax" ) set_physmax( numeric_cast<float64>(value) );
             else if( item == "digmin" ) set_digmin( numeric_cast<float64>(value) );
             else if( item == "digmax" ) set_digmax( numeric_cast<float64>(value) );
+#ifdef ALLOW_GDF_V_251
             else if( item == "toffset" ) set_toffset( numeric_cast<float32>(value) );
+#endif
             else if( item == "lowpass" ) set_lowpass( numeric_cast<float32>(value) );
             else if( item == "highpass" ) set_highpass( numeric_cast<float32>(value) );
             else if( item == "notch" ) set_notch( numeric_cast<float32>(value) );
@@ -125,7 +127,9 @@ namespace gdf
             else if( item == "physmax" ) return numeric_cast<T>(get_physmax( ));
             else if( item == "digmin" ) return numeric_cast<T>(get_digmin( ));
             else if( item == "digmax" ) return numeric_cast<T>(get_digmax( ));
+#ifdef ALLOW_GDF_V_251
             else if( item == "toffset" ) return numeric_cast<T>(get_toffset( ));
+#endif
             else if( item == "lowpass" ) return numeric_cast<T>(get_lowpass( ));
             else if( item == "highpass" ) return numeric_cast<T>(get_highpass( ));
             else if( item == "notch" ) return numeric_cast<T>(get_notch( ));

--- a/libgdf/include/GDF/TagHeader.h
+++ b/libgdf/include/GDF/TagHeader.h
@@ -54,7 +54,7 @@ namespace gdf
         void setValue( std::vector <unsigned char> value ){ m_value = value; }
 
         /// Get the value 
-        const std::vector <unsigned char> & getValue() { return m_value; }
+        const std::vector <unsigned char> & getValue() const { return m_value; }
 
         /// Update the output representation of the T-L-V field. 
         virtual void finalize(){;}

--- a/libgdf/include/GDF/TagHeader.h
+++ b/libgdf/include/GDF/TagHeader.h
@@ -54,13 +54,13 @@ namespace gdf
         void setValue( std::vector <unsigned char> value ){ m_value = value; }
 
         /// Get the value 
-        std::vector <unsigned char> & getValue() { return m_value; }
+        const std::vector <unsigned char> & getValue() { return m_value; }
 
         /// Update the output representation of the T-L-V field. 
         virtual void finalize(){;}
 
         // Return the tag number
-        int getTagNumber(){return int(m_tag);}
+        int getTagNumber() const {return int(m_tag);}
 
     private:
         std::vector <unsigned char> m_value;

--- a/libgdf/src/EventDescriptor.cpp
+++ b/libgdf/src/EventDescriptor.cpp
@@ -132,9 +132,7 @@ namespace gdf
         std::string token;
         uint16 eventType;
         std::string eventDesc;
-        size_t lineNum = 0;
         while (getline(infile, line)){
-            lineNum++;
             if( (line.length() > 0) && (line.c_str()[0] != '#') ) {
                 std::stringstream strstr(line);
                 std::getline(strstr, token, '\t');

--- a/libgdf/src/EventDescriptor.cpp
+++ b/libgdf/src/EventDescriptor.cpp
@@ -182,7 +182,7 @@ namespace gdf
     //===================================================================================================
     //===================================================================================================
 
-    void EventDescriptor::fromTagField( TagField &tf )
+    void EventDescriptor::fromTagField(const TagField &tf )
     {
         // Format the m_value info into the other data structures
         size_t tagfieldlength = tf.getLength();//m_value.size();

--- a/libgdf/src/GDFHeaderAccess.cpp
+++ b/libgdf/src/GDFHeaderAccess.cpp
@@ -382,6 +382,9 @@ namespace gdf
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).physmax.tostream( out );
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).digmin.tostream( out );
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).digmax.tostream( out );
+#ifdef ALLOW_GDF_V_251
+        for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).toffset.tostream( out );
+#endif
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).reserved_1.tostream( out );
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).lowpass.tostream( out );
         for( uint16 i=0; i<ns; i++ ) hdr.getSignalHeader_readonly(i).highpass.tostream( out );

--- a/libgdf/src/GDFHeaderAccess.cpp
+++ b/libgdf/src/GDFHeaderAccess.cpp
@@ -399,9 +399,10 @@ namespace gdf
 
         // write GDF header 3
         hdr.getTagHeader_readonly( ).toStream( out );
+#ifdef NDEBUG
         uint16 header3LenBlocks = mh->get_header_length() - (1+ns);
         assert( out.tellp() == std::streampos(256+256*ns+256*header3LenBlocks));
-        (void)header3LenBlocks; // To prevent -Werror=unused-variable in a release build.
+#endif
 
         return out;
     }

--- a/libgdf/src/Reader.cpp
+++ b/libgdf/src/Reader.cpp
@@ -67,11 +67,7 @@ namespace gdf
         {
             size_t samplesize = datatype_size( m_header.getSignalHeader_readonly( i ).get_datatype( ) );
             m_record_length += samplesize * m_header.getSignalHeader_readonly( i ).get_samples_per_record( );
-#ifdef ALLOW_GDF_V_251
-            double fs = m_header.getSignalHeader( i ).get_samples_per_record( );
-#else
             double fs = m_header.getSignalHeader( i ).get_samples_per_record( ) * m_header.getMainHeader_readonly().get_datarecord_duration(1) / m_header.getMainHeader_readonly().get_datarecord_duration(0);
-#endif
             m_header.getSignalHeader( i ).set_samplerate( boost::numeric_cast<uint32>(fs) );
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.12 )
 project( gdf_tests )
 
 if( UNIX )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable( testDataTypes testDataTypes.cpp )
 target_link_libraries( testDataTypes ${Boost_LIBRARIES} GDF )
 add_test( NAME testDataTypes COMMAND testDataTypes )
 
-# Avoid running tests that use the same file test.gdf.tmp  in parrallel
+# Avoid running tests that use the same file test.gdf.tmp running in parrallel
 
 set_tests_properties(testCreateGDF testRWConsistency testBlit testSparseSampling testHeader3 PROPERTIES RESOURCE_LOCK test.gdf.tmp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,5 +52,9 @@ add_executable( testDataTypes testDataTypes.cpp )
 target_link_libraries( testDataTypes ${Boost_LIBRARIES} GDF )
 add_test( NAME testDataTypes COMMAND testDataTypes )
 
+# Avoid running tests that use the same file test.gdf.tmp  in parrallel
+
+set_tests_properties(testCreateGDF testRWConsistency testBlit testSparseSampling testHeader3 PROPERTIES RESOURCE_LOCK test.gdf.tmp)
+
 #add_custom_target( buildtests DEPENDS testCreateGDF testRWConsistency )
 #add_custom_target( check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS buildtests )

--- a/test/testBlit.cpp
+++ b/test/testBlit.cpp
@@ -188,7 +188,7 @@ int main( )
             cout << "OK" << endl;
 
             w.close( );
-            cout << "Comparing files .... ";
+            cout << "Comparing files .... " << reffile << " and " << testfile << std::endl;
             if( !fcompare( reffile, testfile ) )
             {
                 cout << "Failed." << endl;

--- a/test/testHeader3.cpp
+++ b/test/testHeader3.cpp
@@ -278,7 +278,7 @@ int main( )
             cout << "OK" << endl;
 
             w.close( );
-            cout << "Comparing files .... ";
+            cout << "Comparing files .... " << reffile  << " and " << testfile << std::endl;
             if( !fcompare( reffile, testfile ) )
             {
                 cout << "Failed." << endl;

--- a/test/testRWConsistency.cpp
+++ b/test/testRWConsistency.cpp
@@ -183,7 +183,7 @@ int main( )
             cout << "OK" << endl;
 
             w.close( );
-            cout << "Comparing files .... ";
+            cout << "Comparing files .... " << reffile << " and " << testfile << std::endl;
             if( !fcompare( reffile, testfile ) )
             {
                 cout << "Failed." << endl;

--- a/test/testSparseSampling.cpp
+++ b/test/testSparseSampling.cpp
@@ -202,7 +202,7 @@ int main( )
             cout << endl << "OK" << endl;
 
             w.close( );
-            cout << "Comparing files .... ";
+            cout << "Comparing files .... " << reffile << " and " << testfile << std::endl;
             if( !fcompare( reffile, testfile ) )
             {
                 cout << "Failed." << endl;

--- a/tools/gdf_merger/CMakeLists.txt
+++ b/tools/gdf_merger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.12 )
 project( gdf_merger )
 
 if( UNIX )


### PR DESCRIPTION
This is a set of patches to improve support of GDF 2.51.
First it adds a way to compile in this mode in cmake with the option VERSION_251.
Then it properly declares and handles the toffset field (previously there were missing needed code lines).
Then it revisits the event, to correct/improve their handling:
- 0 means end of table event which was not handled properly (reading was not interrupted).
- recognize modes 5 and 7 (even though the time stamps are not read).
- The reading logic was slightly improved.
- Some exceptions were converted to warnings to avoid terminating the calling program just for small errors.

Finally, the 2.51 mode introduced a wrong computation for sampling rate, which is corrected.
Some methods are marked as const to improve (in one case it should improve efficiency).
A better way to avoid a warning was also introduced that makes more explicit that the not used
quantity depends on debug mode.